### PR TITLE
Fix access of removed rows in Comedock

### DIFF
--- a/addons/Comedot/ComponentsDock.gd
+++ b/addons/Comedot/ComponentsDock.gd
@@ -308,7 +308,7 @@ func onComponentsTree_itemSelected() -> void:
 
 	# Clear the previous selection. These values must be reset in any case.
 
-	removeComponentRowButtons(selectedComponentRow) # Remove the buttons from any previous selection
+	if selectedComponentRow: removeComponentRowButtons(selectedComponentRow) # Remove the buttons from any previous selection
 
 	selectedComponentRow = null
 	selectedComponentCategory = null


### PR DESCRIPTION
After selecting a Component and performing a Rescan Folders, the `componentsTree.clear()` method is called, which causes the `selectedComponentRow` to become a Freed Object. To avoid this issue, a check should be performed before calling `removeComponentRowButtons(selectedComponentRow)`.

Reproduce:Select a Component, then click the Rescan Folders button, and select a Component again. The following error will occur: 
```
res://addons/Comedot/ComponentsDock.gd:311 - Invalid type in function 'removeComponentRowButtons' in base 'Panel (ComponentsDock)'. The Object-derived class of argument 1 (previously freed) is not a subclass of the expected argument class.
```