### PR TITLE
Fix null check in removeComponents: use entity not class Entity

### DIFF
--- a/Resources/Payloads/ComponentPayload.gd
+++ b/Resources/Payloads/ComponentPayload.gd
@@ -29,12 +29,12 @@ func executeImplementation(source: Variant, target: Variant) -> Array[Component]
 
 
 func removeComponents(entity: Entity) -> void:
-	if not Entity or componentsToRemove.is_empty(): return
+	if not is_instance_valid(entity) or componentsToRemove.is_empty(): return
 	entity.removeComponents(componentsToRemove)
 
 
 ## Returns an array of the newly created [Component]s.
 func createComponents(entity: Entity) -> Array[Component]:
-	if not Entity or componentsToCreate.is_empty(): return []
+	if not is_instance_valid(entity) or componentsToCreate.is_empty(): return []
 	var newComponents: Array[Component] = entity.createNewComponents(componentsToCreate)
 	return newComponents


### PR DESCRIPTION
#### Issue
There is an incorrect check using class `Entity` instead of parameter `entity` in `ComponentPayload`.

#### Fix
Replace class Entity with the param `entity` and `is_instance_valid`.