### PR TITLE
Fix ChaseComponent not stopping movement when disabled

### DIFF
--- a/Components/Movement/ChaseComponent.gd
+++ b/Components/Movement/ChaseComponent.gd
@@ -51,6 +51,7 @@ extends Component
 		if newValue != isEnabled:
 			isEnabled = newValue
 			self.set_physics_process(isEnabled and (is_instance_valid(activeTarget) or shouldUpdateTargetRegularly))
+			if not isEnabled: inputComponent.setMovementInputs(Vector2.ZERO)
 
 #endregion
 


### PR DESCRIPTION
## Description

- `ChaseComponent.isEnabled` stopped `_physics_process` but left the last movement direction stuck on the shared `InputComponent`, so the entity kept moving after being disabled.

## Change
- Set the `InputComponent`'s movement inputs to zero in the `isEnabled` setter when disabling, matching the pattern already used by `OverheadPhysicsComponent`.

- [x ] I have read the guidelines in Conventions.md and Contributing.md
